### PR TITLE
Adds GitHub.Network provider and externalizes all resource names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,14 +109,14 @@ resource "azurerm_network_security_group" "actions_NSG" {
 }
 
 resource "azurerm_virtual_network" "ghvnet" {
-  name                = "actions-vnet"
+  name                = var.vnet_name
   location            = var.location
   resource_group_name = azurerm_network_security_group.actions_NSG.resource_group_name
   address_space       = var.address_space
 }
 
 resource "azurerm_subnet" "subnet" {
-  name                 = "actions-subnet"
+  name                 = var.subnet_name
   resource_group_name  = azurerm_network_security_group.actions_NSG.resource_group_name
   virtual_network_name = azurerm_virtual_network.ghvnet.name
 

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,10 @@ terraform {
   }
 }
 
+resource "azurerm_resource_provider_registration" "github_network_provider" {
+  name = "GitHub.Network"
+}
+
 resource "azurerm_network_security_group" "actions_NSG" {
   name                = var.nsg_name
   location            = var.location

--- a/vars.tf
+++ b/vars.tf
@@ -26,3 +26,15 @@ variable "address_prefixes" {
   type        = list(string)
   default     = ["10.0.0.0/24"]
 }
+
+variable "vnet_name" {
+  description = "Name of virtual network"
+  type = string
+  default = "ghvnet"
+}
+
+variable "subnet_name" {
+  description = "Name of subnet"
+  type = string
+  default = "ghsubnet"
+}


### PR DESCRIPTION
This pull request to the `main.tf` and `vars.tf` files adds flexibility to naming conventions for virtual networks and subnets in Azure by using variables instead of hardcoded values. It also registers the `GitHub.Network` provider to manage network resources in Azure.

Main interface changes:

* <a href="diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL112-R123">`main.tf`</a>: Added flexibility to naming conventions for virtual networks and subnets by using variables instead of hardcoded values, and registered the `GitHub.Network` provider to manage network resources in Azure. <a href="diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL112-R123">[1]</a> <a href="diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR11-R14">[2]</a>

Variable changes:

* <a href="diffhunk://#diff-4405511f188bfea2d197dbc36894b51dc9bdf959656c8c4050f717ebd4166c81R29-R40">`vars.tf`</a>: Added two new variables `vnet_name` and `subnet_name` to customize the names of the virtual network and subnet.