### PR TITLE
Add actions to service_delegation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,7 @@ resource "azurerm_subnet" "subnet" {
 
     service_delegation {
       name = "GitHub.Network/networkSettings"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
     }
   }
 }


### PR DESCRIPTION
These actions are created by default, so adding them here to prevent TF from thinking that it needs to change the resource in future runs.