### PR TITLE
Use template deployment for network settings resource

### DIFF
--- a/nsg/main.tf
+++ b/nsg/main.tf
@@ -10,6 +10,7 @@ terraform {
 locals {
   rg_name = "${var.base_name}-rg"
   ns_name = "${var.base_name}-ns"
+  nsd_name = "${var.base_name}-nsd"
 }
 
 # You need this if you haven't already registered the GitHub.Network resource provider in your Azure subscription.
@@ -152,30 +153,60 @@ resource "azurerm_subnet" "runner_subnet" {
   }
 }
 
-# There is no Terraform provider for GitHub.Network, so we have to use a null_resource and
-# local-exec to call a script that uses the Azure CLI to create the network settings. We
-# can't add these provisioners to the runner subnet resource because a destroy provisioner
-# doesn't have access to any other resources including vars and locals. We need to use these
-# triggers to get those values. 
-
 # WARNING: Deleting this resource will fail if the networkSettings is still in use in github.com. You need
 # to delete resources in github.com before trying to delete the Azure resources.
-resource null_resource github_network_settings {
-  triggers = {
-    ns_name = local.ns_name
-    rg_name = local.rg_name
-    subnet_id = azurerm_subnet.runner_subnet.id
-  }
+resource "azurerm_resource_group_template_deployment" "network_settings" {
+  name                = local.nsd_name
+  resource_group_name = azurerm_resource_group.resource_group.name
+  deployment_mode     = "Complete"
 
-  provisioner "local-exec" {
-    when = create
-    command = "${path.module}/../scripts/create-ns.sh ${self.triggers.rg_name} ${self.triggers.ns_name} ${var.location} ${self.triggers.subnet_id} ${var.github_org_id}"
-  }
+  parameters_content = jsonencode({
+    "ns_name" = {
+      "value" = local.ns_name
+    },
+    "location" = {
+      "value" = var.location
+    },
+    "subnet_id" = {
+      "value" = azurerm_subnet.runner_subnet.id
+    },
+    "github_org_id" = {
+      "value" = var.github_org_id
+    }
+  })
 
-  provisioner "local-exec" {
-    when = destroy
-    command = "${path.module}/../scripts/delete-ns.sh ${self.triggers.rg_name} ${self.triggers.ns_name}"
-  }
+  template_content = <<TEMPLATE
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "ns_name": {
+      "type": "String"
+    },
+    "location": {
+      "type": "String"
+    },
+    "subnet_id": {
+      "type": "String"
+    },
+    "github_org_id": {
+      "type": "String"
+    }
+  },
+  "resources": [
+    {
+      "type": "GitHub.Network/networkSettings",
+      "apiVersion": "2023-11-01-preview",
+      "name": "[parameters('ns_name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "subnetId": "[parameters('subnet_id')]",
+        "organizationId": "[parameters('github_org_id')]"
+      }
+    }
+  ]
+}
+TEMPLATE
 }
 
 resource "azurerm_subnet_network_security_group_association" "subnet_nsg_association" {
@@ -187,6 +218,6 @@ resource "azurerm_subnet_network_security_group_association" "subnet_nsg_associa
 data "azurerm_resources" "github_network_settings" {
   name = local.ns_name
   depends_on = [
-    null_resource.github_network_settings
+    azurerm_resource_group_template_deployment.network_settings
   ]
 }

--- a/scripts/create-ns.sh
+++ b/scripts/create-ns.sh
@@ -1,1 +1,0 @@
-az resource create --resource-group "$1" --name "$2" --resource-type GitHub.Network/networkSettings --properties "{ \"location\": \"$3\", \"properties\" : {  \"subnetId\": \"$4\", \"organizationId\": \"$5\" }}" --is-full-object --output json --query "{GitHubId:tags.GitHubId, name:name}" --api-version 2023-11-01-preview

--- a/scripts/delete-ns.sh
+++ b/scripts/delete-ns.sh
@@ -1,1 +1,0 @@
-az resource delete --resource-group "$1" --name "$2" --resource-type GitHub.Network/networkSettings --api-version 2023-11-01-preview


### PR DESCRIPTION
This uses a [`resource_group_template_deployment`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group_template_deployment) in place of the `local-exec` provisioners to stand up the network settings resource. While Terraform doesn't directly support `GitHub.Network/networkSettings`, I think this is the best alternative. 