### PR TITLE
Change network-settings deployment mode to "Incremental"

### DIFF
--- a/nsg/main.tf
+++ b/nsg/main.tf
@@ -158,7 +158,7 @@ resource "azurerm_subnet" "runner_subnet" {
 resource "azurerm_resource_group_template_deployment" "network_settings" {
   name                = local.nsd_name
   resource_group_name = azurerm_resource_group.resource_group.name
-  deployment_mode     = "Complete"
+  deployment_mode     = "Incremental"
 
   parameters_content = jsonencode({
     "ns_name" = {


### PR DESCRIPTION
In my last PR, I added the network_settings deployment and set `deployment_mode` to `Complete`, which can cause other resources in the resource group to be destroyed. This sets it to `Incremental`, which is safer and the correct choice here.