### PR TITLE
Updates for the VNET injection GA release

### DIFF
--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -134,13 +134,18 @@ resource "azurerm_firewall_policy_rule_collection_group" "firewall_policy_rule_c
       name = "GitHub"
       source_addresses = ["*"]
       destination_fqdns = [
+        # For essential operation
         "github.com",
         "api.github.com",
         "*.actions.githubusercontent.com",
+        # For downloading actions
         "codeload.github.com",
+        # For job summaries, logs, artifacts, and caches
         "*.blob.core.windows.net",
+        # For packages
         "*.pkg.github.com",
         "ghcr.io",
+        # For LFS
         "github-cloud.githubusercontent.com",
         "github-cloud.s3.amazonaws.com"
       ]

--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -115,12 +115,12 @@ resource "azurerm_firewall_policy_rule_collection_group" "firewall_policy_rule_c
 
   network_rule_collection {
     action   = "Allow"
-    name     = "AllowAzureCloud"
+    name     = "AllowAzureStorage"
     priority = 100
     rule {
-      destination_addresses = ["AzureCloud"]
+      destination_addresses = ["Storage"]
       destination_ports     = ["443"]
-      name                  = "AzureCloud"
+      name                  = "AzureStorage"
       protocols             = ["TCP"]
       source_addresses      = ["*"]
     }
@@ -135,24 +135,30 @@ resource "azurerm_firewall_policy_rule_collection_group" "firewall_policy_rule_c
       source_addresses = ["*"]
       destination_fqdns = [
         "github.com",
-        "*.github.com",
-        "*.githubusercontent.com",
-        "*.githubapp.com"
+        "api.github.com",
+        "*.actions.githubusercontent.com",
+        "codeload.github.com",
+        "*.blob.core.windows.net",
+        "*.pkg.github.com",
+        "ghcr.io",
+        "github-cloud.githubusercontent.com",
+        "github-cloud.s3.amazonaws.com"
       ]
       protocols {
         port = "443"
         type = "Https"
       }
     }
-    rule {
-      name = "NPM"
-      source_addresses = ["*"]
-      destination_fqdns = ["registry.npmjs.org"]
-      protocols {
-        port = "443"
-        type = "Https"
-      }
-    }
+    # Sample rule for allowing access to registry.npmjs.org
+    # rule {
+    #   name = "NPM"
+    #   source_addresses = ["*"]
+    #   destination_fqdns = ["registry.npmjs.org"]
+    #   protocols {
+    #     port = "443"
+    #     type = "Https"
+    #   }
+    # }
   }
   depends_on = [
     azurerm_firewall_policy.firewall_policy,
@@ -234,8 +240,8 @@ resource "azurerm_resource_group_template_deployment" "github_network_settings" 
     "subnetId" = {
       value = azurerm_subnet.runner_subnet.id
     },
-    "organizationId" = {
-      value = var.github_enterprise_id
+    "businessId" = {
+      value = var.github_business_id
     },
   })
   template_content    = file("${path.module}/../shared/gh_network_settings_template.json")

--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -134,19 +134,19 @@ resource "azurerm_firewall_policy_rule_collection_group" "firewall_policy_rule_c
       name = "GitHub"
       source_addresses = ["*"]
       destination_fqdns = [
+        # These FQDNs have been taken from the GitHub documentation for self-hosted runner networking
+        # and the https://api.github.com/meta API response. Both sources list more specific FQDNs so 
+        # organizations wishing to minimize use of wildcards can consult those sources to build a more
+        # explicit list of required FQDNs.
         # For essential operation
         "github.com",
-        "api.github.com",
-        "*.actions.githubusercontent.com",
-        # For downloading actions
-        "codeload.github.com",
-        # For job summaries, logs, artifacts, and caches
+        "*.github.com",
+        "*.githubusercontent.com",
         "*.blob.core.windows.net",
         # For packages
-        "*.pkg.github.com",
-        "ghcr.io",
+        "*.ghcr.io",
+        "*.githubassets.com",
         # For LFS
-        "github-cloud.githubusercontent.com",
         "github-cloud.s3.amazonaws.com"
       ]
       protocols {
@@ -154,7 +154,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "firewall_policy_rule_c
         type = "Https"
       }
     }
-    # Sample rule for allowing access to registry.npmjs.org
+    # Sample rule for allowing access to a 3rd party service, the NPM registry at registry.npmjs.org
     # rule {
     #   name = "NPM"
     #   source_addresses = ["*"]

--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -144,6 +144,7 @@ resource "azurerm_firewall_policy_rule_collection_group" "firewall_policy_rule_c
         "*.githubusercontent.com",
         "*.blob.core.windows.net",
         # For packages
+        "ghcr.io",
         "*.ghcr.io",
         "*.githubassets.com",
         # For LFS

--- a/modules/firewall/vars.tf
+++ b/modules/firewall/vars.tf
@@ -33,7 +33,7 @@ variable "firewall_management_subnet_address_prefixes" {
   default     = ["10.0.2.0/26"]
 }
 
-variable "github_enterprise_id" {
-  description = "GitHub Enterprise Database ID"
+variable "github_business_id" {
+  description = "GitHub Enterprise or Organization Database ID"
   type        = string
 }

--- a/modules/nsg/main.tf
+++ b/modules/nsg/main.tf
@@ -59,20 +59,20 @@ resource "azurerm_network_security_group" "actions_nsg" {
   }
 
   security_rule {
-    name                         = "AllowAzureCloudOutBound"
+    name                         = "AllowStorageOutBound"
     source_port_range            = "*"
-    destination_port_range       = "443"
+    destination_port_range       = "*"
     source_address_prefix        = "*"
-    destination_address_prefix   = "AzureCloud"
+    destination_address_prefix   = "Storage"
     access                       = "Allow"
-    priority                     = 210
+    priority                     = 230
     direction                    = "Outbound"
     destination_address_prefixes = []
-    protocol                     = "Tcp"
+    protocol                     = "*"
   }
 
   security_rule {
-    name                   = "AllowInternetOutBoundGitHub"
+    name                   = "AllowOutBoundGitHub"
     protocol               = "Tcp"
     source_port_range      = "*"
     destination_port_range = "443"
@@ -81,51 +81,167 @@ resource "azurerm_network_security_group" "actions_nsg" {
     priority               = 220
     direction              = "Outbound"
     destination_address_prefixes = [
-      "140.82.112.0/20",
-      "142.250.0.0/15",
-      "143.55.64.0/20",
-      "192.30.252.0/22",
-      "185.199.108.0/22"
+            "140.82.112.0/20",
+            "143.55.64.0/20",
+            "185.199.108.0/22",
+            "192.30.252.0/22",
+            "20.175.192.146/32",
+            "20.175.192.147/32",
+            "20.175.192.149/32",
+            "20.175.192.150/32",
+            "20.199.39.227/32",
+            "20.199.39.228/32",
+            "20.199.39.231/32",
+            "20.199.39.232/32",
+            "20.200.245.241/32",
+            "20.200.245.245/32",
+            "20.200.245.246/32",
+            "20.200.245.247/32",
+            "20.200.245.248/32",
+            "20.201.28.144/32",
+            "20.201.28.148/32",
+            "20.201.28.149/32",
+            "20.201.28.151/32",
+            "20.201.28.152/32",
+            "20.205.243.160/32",
+            "20.205.243.164/32",
+            "20.205.243.165/32",
+            "20.205.243.166/32",
+            "20.205.243.168/32",
+            "20.207.73.82/32",
+            "20.207.73.83/32",
+            "20.207.73.85/32",
+            "20.207.73.86/32",
+            "20.207.73.88/32",
+            "20.233.83.145/32",
+            "20.233.83.146/32",
+            "20.233.83.147/32",
+            "20.233.83.149/32",
+            "20.233.83.150/32",
+            "20.248.137.48/32",
+            "20.248.137.49/32",
+            "20.248.137.50/32",
+            "20.248.137.52/32",
+            "20.248.137.55/32",
+            "20.27.177.113/32",
+            "20.27.177.114/32",
+            "20.27.177.116/32",
+            "20.27.177.117/32",
+            "20.27.177.118/32",
+            "20.29.134.17/32",
+            "20.29.134.18/32",
+            "20.29.134.19/32",
+            "20.29.134.23/32",
+            "20.29.134.24/32",
+            "20.87.245.0/32",
+            "20.87.245.1/32",
+            "20.87.245.4/32",
+            "20.87.245.6/32",
+            "20.87.245.7/32",
+            "4.208.26.196/32",
+            "4.208.26.197/32",
+            "4.208.26.198/32",
+            "4.208.26.199/32",
+            "4.208.26.200/32"
     ]
   }
 
   security_rule {
-    name                   = "AllowInternetOutBoundMicrosoft"
+    name                   = "AllowOutBoundActions"
     protocol               = "Tcp"
     source_port_range      = "*"
     destination_port_range = "443"
     source_address_prefix  = "*"
     access                 = "Allow"
-    priority               = 230
+    priority               = 210
     direction              = "Outbound"
     destination_address_prefixes = [
-      "13.64.0.0/11",
-      "13.96.0.0/13",
-      "13.104.0.0/14",
-      "20.33.0.0/16",
-      "20.34.0.0/15",
-      "20.36.0.0/14",
-      "20.40.0.0/13",
-      "20.48.0.0/12",
-      "20.64.0.0/10",
-      "20.128.0.0/16",
-      "52.224.0.0/11",
-      "204.79.197.200"
+            "4.175.114.51/32",
+            "20.102.35.120/32",
+            "4.175.114.43/32",
+            "20.72.125.48/32",
+            "20.19.5.100/32",
+            "20.7.92.46/32",
+            "20.232.252.48/32",
+            "52.186.44.51/32",
+            "20.22.98.201/32",
+            "20.246.184.240/32",
+            "20.96.133.71/32",
+            "20.253.2.203/32",
+            "20.102.39.220/32",
+            "20.81.127.181/32",
+            "52.148.30.208/32",
+            "20.14.42.190/32",
+            "20.85.159.192/32",
+            "52.224.205.173/32",
+            "20.118.176.156/32",
+            "20.236.207.188/32",
+            "20.242.161.191/32",
+            "20.166.216.139/32",
+            "20.253.126.26/32",
+            "52.152.245.137/32",
+            "40.118.236.116/32",
+            "20.185.75.138/32",
+            "20.96.226.211/32",
+            "52.167.78.33/32",
+            "20.105.13.142/32",
+            "20.253.95.3/32",
+            "20.221.96.90/32",
+            "51.138.235.85/32",
+            "52.186.47.208/32",
+            "20.7.220.66/32",
+            "20.75.4.210/32",
+            "20.120.75.171/32",
+            "20.98.183.48/32",
+            "20.84.200.15/32",
+            "20.14.235.135/32",
+            "20.10.226.54/32",
+            "20.22.166.15/32",
+            "20.65.21.88/32",
+            "20.102.36.236/32",
+            "20.124.56.57/32",
+            "20.94.100.174/32",
+            "20.102.166.33/32",
+            "20.31.193.160/32",
+            "20.232.77.7/32",
+            "20.102.38.122/32",
+            "20.102.39.57/32",
+            "20.85.108.33/32",
+            "40.88.240.168/32",
+            "20.69.187.19/32",
+            "20.246.192.124/32",
+            "20.4.161.108/32",
+            "20.22.22.84/32",
+            "20.1.250.47/32",
+            "20.237.33.78/32",
+            "20.242.179.206/32",
+            "40.88.239.133/32",
+            "20.121.247.125/32",
+            "20.106.107.180/32",
+            "20.22.118.40/32",
+            "20.15.240.48/32",
+            "20.84.218.150/32"
     ]
   }
 
-  security_rule {
-    name                         = "AllowInternetOutBoundCannonical"
-    protocol                     = "Tcp"
-    source_port_range            = "*"
-    destination_port_range       = "443"
-    source_address_prefix        = "*"
-    access                       = "Allow"
-    priority                     = 240
-    direction                    = "Outbound"
-    destination_address_prefix   = "185.125.188.0/22"
-    destination_address_prefixes = []
-  }
+  # Example rule for allowing access to NPM (registry.npmjs.org)
+  # Note: At the time of writing, this IP range will enable access to registry.npmjs.org
+  # but broader than it needs to be. If you want to restrict access to only registry.npmjs.org, you
+  # should use a tighter range. This is just an example.
+  # security_rule {
+  #   name                   = "AllowOutBoundNPM"
+  #   protocol               = "Tcp"
+  #   source_port_range      = "*"
+  #   destination_port_range = "443"
+  #   source_address_prefix  = "*"
+  #   access                 = "Allow"
+  #   priority               = 240
+  #   direction              = "Outbound"
+  #   destination_address_prefixes = [
+  #     "104.16.0.0/16"
+  #   ]
+  # }
+
 }
 
 resource "azurerm_virtual_network" "vnet" {
@@ -170,8 +286,8 @@ resource "azurerm_resource_group_template_deployment" "github_network_settings" 
     "subnetId" = {
       value = azurerm_subnet.runner_subnet.id
     },
-    "organizationId" = {
-      value = var.github_enterprise_id
+    "businessId" = {
+      value = var.github_business_id
     },
   })
   template_content    = file("${path.module}/../shared/gh_network_settings_template.json")

--- a/modules/nsg/vars.tf
+++ b/modules/nsg/vars.tf
@@ -21,7 +21,7 @@ variable "runner_subnet_address_prefixes" {
   default     = ["10.0.0.0/24"]
 }
 
-variable "github_enterprise_id" {
-  description = "GitHub Enterprise Database ID"
+variable "github_business_id" {
+  description = "GitHub Enterprise or Organization Database ID"
   type        = string
 }

--- a/modules/shared/gh_network_settings_template.json
+++ b/modules/shared/gh_network_settings_template.json
@@ -8,10 +8,10 @@
                 "description": "The name of the GitHub Network Settings resource."
             }
         },
-        "organizationId": {
+        "businessId": {
             "type": "string",
             "metadata": {
-                "description": "The ID of the GitHub organization."
+                "description": "The database ID of the GitHub enterprise or organization."
             }
         },
         "subnetId": {
@@ -22,7 +22,7 @@
         },
         "apiVersion": {
             "type": "string",
-            "defaultValue": "2023-11-01-preview",
+            "defaultValue": "2024-04-02",
             "metadata": {
                 "description": "The API version of the GitHub Network Settings resource."
             }
@@ -35,7 +35,7 @@
             "name": "[parameters('name')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "organizationId": "[parameters('organizationId')]",
+                "businessId": "[parameters('businessId')]",
                 "subnetId": "[parameters('subnetId')]"
             }
         }


### PR DESCRIPTION
Changes to support the GA release. The only required changes were in the structure of the `GitHub.Network/networkSettings` resource where the `organizationId` property was renamed to `businessId`. I also changed our related variable names.

The other changes were around the network access rules for both the NSG and Firewall configuration. The NSG configuration is a direct reflection of the updated documentation and bicep file provided by GitHub. After some discussion with the private networking engineering team, I used the self-hosted runner networking documentation and the meta API response to build the Firewall network access rules. The Firewall rules are more open than they would have to be, but I think for these purposes it's OK to use FQDN wildcards liberally so we're not constantly chasing those domain name definitions, and let customers enforce tighter rules if they want.