### PR TITLE
Standardize business ID variable names and descriptions

### DIFF
--- a/examples/example-firewall/main.tf
+++ b/examples/example-firewall/main.tf
@@ -3,5 +3,5 @@ module "vnet" {
     source = "github.com/garnertb/github-runner-vnet//modules/firewall"
 
     base_name = var.base_name
-    github_enterprise_id = var.github_enterprise_id
+    github_business_id = var.github_business_id
 }

--- a/examples/example-firewall/vars.tf
+++ b/examples/example-firewall/vars.tf
@@ -3,7 +3,7 @@ variable "base_name" {
   type        = string
 }
 
-variable "github_enterprise_id" {
-  description = "GitHub Enterprise Database ID"
+variable "github_business_id" {
+  description = "GitHub Enterprise or Organization Database ID"
   type        = string
 }

--- a/examples/example-nsg/main.tf
+++ b/examples/example-nsg/main.tf
@@ -3,5 +3,5 @@ module "vnet" {
     source = "github.com/garnertb/github-runner-vnet//modules/nsg"
 
     base_name = var.base_name
-    github_enterprise_id = var.github_enterprise_id
+    github_business_id = var.github_business_id
 }

--- a/examples/example-nsg/vars.tf
+++ b/examples/example-nsg/vars.tf
@@ -3,7 +3,7 @@ variable "base_name" {
   type        = string
 }
 
-variable "github_enterprise_id" {
-  description = "GitHub Enterprise Database ID"
+variable "github_business_id" {
+  description = "GitHub Enterprise or Organization Database ID"
   type        = string
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ module "vnet" {
     source = "./modules/nsg"
 
     base_name = var.base_name
-    github_enterprise_id = var.github_enterprise_id
+    github_business_id = var.github_business_id
     location = var.location
     vnet_address_space = var.vnet_address_space
     runner_subnet_address_prefixes = var.runner_subnet_address_prefixes

--- a/vars.tf
+++ b/vars.tf
@@ -21,7 +21,7 @@ variable "runner_subnet_address_prefixes" {
   default     = ["10.0.0.0/24"]
 }
 
-variable "github_enterprise_id" {
-  description = "GitHub Enterprise Database ID"
+variable "github_business_id" {
+  description = "GitHub Enterprise or Organization Database ID"
   type        = string
 }


### PR DESCRIPTION
Had a few remaining uses of "enterprise ID" instead of the newer "business ID" which is what the GA release uses for the enterprise or organization database ID, in the `networkSettings` resource payload. Standardize on using `github_business_id` for the variable names and a better description.